### PR TITLE
Feature/start schemaregistry ondemand

### DIFF
--- a/kaa-registry-server/src/main/scala/kaa/schemaregistry/server/EntryPoint.scala
+++ b/kaa-registry-server/src/main/scala/kaa/schemaregistry/server/EntryPoint.scala
@@ -28,7 +28,12 @@ object EntryPoint extends App {
 
   val doneSignal = new CountDownLatch(1)
 
-  val schemaRegistry = new KaaSchemaRegistry(brokers)
+  def onError(ex: Exception): Unit = {
+    println(ex)
+    doneSignal.countDown()
+  }
+
+  val schemaRegistry = new KaaSchemaRegistry(brokers, onError)
   try {
     val controller = new KaaController(schemaRegistry)
 
@@ -42,10 +47,11 @@ object EntryPoint extends App {
 
     Runtime.getRuntime.addShutdownHook(new Thread(() => {
       doneSignal.countDown()
-      httpServer.stop()
     }))
 
     doneSignal.await()
+
+    httpServer.stop()
   } finally {
     schemaRegistry.close()
   }

--- a/kaa-registry-server/src/main/scala/kaa/schemaregistry/server/EntryPoint.scala
+++ b/kaa-registry-server/src/main/scala/kaa/schemaregistry/server/EntryPoint.scala
@@ -35,6 +35,7 @@ object EntryPoint extends App {
 
   val schemaRegistry = new KaaSchemaRegistry(brokers, onError)
   try {
+    schemaRegistry.start()
     val controller = new KaaController(schemaRegistry)
 
     val httpServer = new KaaHttpServer(

--- a/kaa/src/it/resources/logback.xml
+++ b/kaa/src/it/resources/logback.xml
@@ -6,6 +6,10 @@
         </encoder>
     </appender>
 
+    <logger name="KaaSchemaRegistry" level="debug" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>

--- a/kaa/src/it/scala/KaaSchemaRegistrySpec.scala
+++ b/kaa/src/it/scala/KaaSchemaRegistrySpec.scala
@@ -28,7 +28,7 @@ class KaaSchemaRegistrySpec extends AnyFlatSpec with should.Matchers with Before
   }
 
   override protected def afterAll(): Unit = {
-    // admin.deleteTopic()
+    admin.deleteTopic()
   }
 
   "KaaSchemaRegistry" should "create" in {

--- a/kaa/src/it/scala/KaaSchemaRegistrySpec.scala
+++ b/kaa/src/it/scala/KaaSchemaRegistrySpec.scala
@@ -1,10 +1,12 @@
 import java.util.UUID
-
-import kaa.schemaregistry.{KaaSchemaRegistry, KaaSchemaRegistryAdmin, SchemaId}
+import kaa.schemaregistry.{InvalidStateException, KaaSchemaRegistry, KaaSchemaRegistryAdmin, SchemaId}
 import com.sksamuel.avro4s.AvroSchema
 import org.scalatest._
 import org.scalatest.flatspec._
 import org.scalatest.matchers._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Try}
 
 class KaaSchemaRegistrySpec extends AnyFlatSpec with should.Matchers with BeforeAndAfterAll {
 
@@ -17,7 +19,7 @@ class KaaSchemaRegistrySpec extends AnyFlatSpec with should.Matchers with Before
   )
 
   private def createTarget() = {
-    new KaaSchemaRegistry(props, props, topic = TOPIC_NAME)
+    new KaaSchemaRegistry(props, props, ex => println(ex), topic = TOPIC_NAME)
   }
 
   override protected def beforeAll(): Unit = {
@@ -26,20 +28,74 @@ class KaaSchemaRegistrySpec extends AnyFlatSpec with should.Matchers with Before
   }
 
   override protected def afterAll(): Unit = {
-    admin.deleteTopic()
+    // admin.deleteTopic()
   }
 
-  "KaaSchemaRegistry" should "put and retrieve a schema" in {
-    val target = createTarget()
+  "KaaSchemaRegistry" should "create" in {
+    val _ = createTarget()
+    succeed
+  }
 
+  it should "cannot put schema if not starter" in {
+    val target = createTarget()
+    val schema = AvroSchema[Foo]
+    Try(target.put(schema)) match {
+      case Success(_) => fail("Expected to fail")
+      case Failure(_: InvalidStateException) => succeed
+      case Failure(_) => fail("Expected to fail with InvalidStateException")
+    }
+  }
+
+  it should "cannot get schema if not starter" in {
+    val target = createTarget()
+    target.get(SchemaId(999L)) match {
+      case Some(_) => fail("Expected None")
+      case None => succeed
+    }
+  }
+
+  it should "put and get a schema" in {
+    val target = createTarget()
     try {
+      target.start()
+
       val schema = AvroSchema[Foo]
       val schemaId = target.put(schema)
 
       target.get(schemaId) match {
-        case None => fail("Schema not found")
         case Some(schemaRetrieved) => schemaRetrieved should be (schema)
+        case None => fail("Schema not found")
       }
+    } finally {
+      target.close()
+    }
+  }
+
+  it should "put and get a schema then close and start again" in {
+    val target = createTarget()
+    try {
+      target.start()
+
+      val schema = AvroSchema[Foo]
+      val schemaId = target.put(schema)
+
+      target.get(schemaId) match {
+        case Some(schemaRetrieved) => schemaRetrieved should be (schema)
+        case None => fail("Schema not found")
+      }
+
+      target.close()
+      target.get(schemaId) match {
+        case Some(_) => fail("Expected None")
+        case None => succeed
+      }
+
+      target.start()
+      target.get(schemaId) match {
+        case Some(schemaRetrieved) => schemaRetrieved should be (schema)
+        case None => fail("Schema not found")
+      }
+
     } finally {
       target.close()
     }
@@ -47,11 +103,12 @@ class KaaSchemaRegistrySpec extends AnyFlatSpec with should.Matchers with Before
 
   it should "return None for not existing schema" in {
     val target = createTarget()
-
     try {
+      target.start()
+
       target.get(SchemaId(999L)) match {
-        case None => succeed
         case Some(_) => fail("Schema should not be retrieved")
+        case None => succeed
       }
     } finally {
       target.close()

--- a/kaa/src/main/scala-2.12/kaa/schemaregistry/utils/CollectionConverters.scala
+++ b/kaa/src/main/scala-2.12/kaa/schemaregistry/utils/CollectionConverters.scala
@@ -1,9 +1,10 @@
 package kaa.schemaregistry.utils
 
+import java.util
 import collection.JavaConverters._
 
 object CollectionConverters {
-    def mapAsJava[K, V](map: Map[K, V]) = {
+    def mapAsJava[K, V](map: Map[K, V]): util.Map[K, V] = {
         map.asJava
     }
 }

--- a/kaa/src/main/scala-2.13/kaa/schemaregistry/utils/CollectionConverters.scala
+++ b/kaa/src/main/scala-2.13/kaa/schemaregistry/utils/CollectionConverters.scala
@@ -1,9 +1,10 @@
 package kaa.schemaregistry.utils
 
+import java.util
 import scala.jdk.CollectionConverters._
 
 object CollectionConverters {
-    def mapAsJava[K, V](map: Map[K, V]) = {
+    def mapAsJava[K, V](map: Map[K, V]): util.Map[K, V] = {
         map.asJava
     }
 }

--- a/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
@@ -110,7 +110,7 @@ class KaaSchemaRegistry(
       case Some(p) => p.close(maxWait)
       case None =>
     }
-    cache.cleanUp()
+    cache.invalidateAll()
     stopping.set(false)
   }
 
@@ -139,7 +139,6 @@ class KaaSchemaRegistry(
         while (!stopping.get()) {
           logger.debug(s"Polling from topic $topic")
           val records = consumer.poll(jPollInterval)
-
           records.forEach(record => {
             logger.debug(s"Found schema ${record.key()}")
             cache.put(record.key(), record.value())

--- a/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
@@ -35,10 +35,10 @@ object KaaSchemaRegistry {
             brokers: String,
             clientId: String = DEFAULT_CLIENT_ID,
           ): Properties = {
-    val consumerProps = new Properties()
-    consumerProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokers)
-    consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId)
-    consumerProps
+    val props = new Properties()
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    props.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId)
+    props
   }
 }
 

--- a/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
@@ -14,13 +14,12 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{LongDeserializer, StringDeserializer}
 import org.apache.kafka.common.serialization.{LongSerializer, StringSerializer}
 import org.apache.kafka.clients.CommonClientConfigs
-
 import kaa.schemaregistry.utils.Retry
 import kaa.schemaregistry.utils.RetryConfig
 import kaa.schemaregistry.KaaSchemaRegistry._
 
 import scala.concurrent.duration._
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.concurrent._
 
 object KaaSchemaRegistry {
@@ -30,9 +29,9 @@ object KaaSchemaRegistry {
   val DEFAULT_RETRY_CONFIG: RetryConfig = RetryConfig(5, 2.second)
 
   def createProps(
-            brokers: String,
-            clientId: String = DEFAULT_CLIENT_ID,
-          ): Properties = {
+                   brokers: String,
+                   clientId: String = DEFAULT_CLIENT_ID,
+                 ): Properties = {
     val props = new Properties()
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokers)
     props.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId)
@@ -41,69 +40,69 @@ object KaaSchemaRegistry {
 }
 
 class KaaSchemaRegistry(
-  producerProps: Properties,
-  consumerProps: Properties,
-  topic: String = DEFAULT_TOPIC_NAME,
-  pollInterval: Duration = DEFAULT_POLL_INTERVAL,
-  getRetry: RetryConfig = DEFAULT_RETRY_CONFIG
-) extends SchemaRegistry {
+                         producerProps: Properties,
+                         consumerProps: Properties,
+                         topic: String = DEFAULT_TOPIC_NAME,
+                         pollInterval: Duration = DEFAULT_POLL_INTERVAL,
+                         getRetry: RetryConfig = DEFAULT_RETRY_CONFIG,
+                         onError: Exception => Unit
+                       ) extends SchemaRegistry {
 
   def this(producerProps: Properties,
-           consumerProps: Properties) = {
+           consumerProps: Properties,
+           onError: Exception => Unit,
+          ) = {
     this(
       producerProps = producerProps,
       consumerProps = consumerProps,
       topic = DEFAULT_TOPIC_NAME,
       pollInterval = DEFAULT_POLL_INTERVAL,
       getRetry = DEFAULT_RETRY_CONFIG,
+      onError,
     )
   }
-  def this(brokers: String) = {
+
+  def this(brokers: String, onError: Exception => Unit) = {
     this(
       producerProps = createProps(brokers),
       consumerProps = createProps(brokers),
+      onError,
     )
   }
 
-  implicit private val ec: ExecutionContextExecutor = ExecutionContext.global
-
-  private val producer = createProducer()
-  private val consumer = createConsumer()
   private val cache: Cache[Long, String] = Scaffeine().build[Long, String]()
   private val stopping = new AtomicBoolean(false)
-  private val startConsumerFuture = startConsumer()
+  private val producer = new AtomicReference[Option[KaaProducer]]
+  private val consumer = new AtomicReference[Option[KaaConsumer]]
 
-  private def startConsumer(): Future[Unit] = Future {
-    consumer.subscribe(Collections.singletonList(topic))
-    val jPollInterval = JavaDuration.ofMillis(pollInterval.toMillis)
-    while (!stopping.get()) {
-      val records = consumer.poll(jPollInterval)
-
-      records.forEach(record => {
-        cache.put(record.key(), record.value())
-      })
-    }
+  def start()(implicit ec: ExecutionContext): Unit = {
+    if (!stopping.get())
+      throw InvalidStateException("Schema registry is stopping")
+    if (!producer.compareAndSet(None, Some(new KaaProducer())))
+      throw InvalidStateException("Schema registry already started")
+    if (!consumer.compareAndSet(None, Some(new KaaConsumer())))
+      throw InvalidStateException("Schema registry already started")
   }
 
   def close(maxWait: Duration = 10.seconds): Unit = {
     stopping.set(true)
-    Await.result(startConsumerFuture, maxWait)
-    val maxWaitJava = JavaDuration.ofMillis(maxWait.toMillis)
-    consumer.close(maxWaitJava)
-    producer.close(maxWaitJava)
+    consumer.getAndSet(None) match {
+      case Some(c) => c.close(maxWait)
+      case None =>
+    }
+    producer.getAndSet(None) match {
+      case Some(p) => p.close(maxWait)
+      case None =>
+    }
+    cache.cleanUp()
+    stopping.set(false)
   }
 
   override def put(schema: Schema): SchemaId = {
-    if (stopping.get()) throw new UnsupportedOperationException("KaaSchemaRegistry is not available")
-
-    val fingerprint = SchemaNormalization.parsingFingerprint64(schema)
-
-    if (cache.getIfPresent(fingerprint).isEmpty) {
-      val record = new ProducerRecord[java.lang.Long, String](topic, fingerprint, schema.toString())
-      producer.send(record).get()
+    producer.get() match {
+      case Some(p) => p.put(schema)
+      case None => throw InvalidStateException("Schema registry not started")
     }
-
-    SchemaId(fingerprint)
   }
 
   override def get(id: SchemaId): Option[Schema] = {
@@ -113,28 +112,77 @@ class KaaSchemaRegistry(
     }
   }
 
-  protected def createConsumer(): KafkaConsumer[lang.Long, String] = {
-    new KafkaConsumer(fillConsumerProps(), new LongDeserializer(), new StringDeserializer())
+  class KaaConsumer()(implicit ec: ExecutionContext) {
+    private val consumer = createConsumer()
+    private val startConsumerFuture = startConsumer()
+
+    private def startConsumer(): Future[Unit] = Future {
+      try {
+        consumer.subscribe(Collections.singletonList(topic))
+        val jPollInterval = JavaDuration.ofMillis(pollInterval.toMillis)
+        while (!stopping.get()) {
+          val records = consumer.poll(jPollInterval)
+
+          records.forEach(record => {
+            cache.put(record.key(), record.value())
+          })
+        }
+      } catch {
+        case ex: Exception => onError(ex)
+      }
+    }
+
+    def close(maxWait: Duration): Unit = {
+      Await.result(startConsumerFuture, maxWait)
+      val maxWaitJava = JavaDuration.ofMillis(maxWait.toMillis)
+      consumer.close(maxWaitJava)
+    }
+
+    protected def createConsumer(): KafkaConsumer[lang.Long, String] = {
+      new KafkaConsumer(fillConsumerProps(), new LongDeserializer(), new StringDeserializer())
+    }
+
+    protected def fillConsumerProps(): Properties = {
+
+      consumerProps.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, KaaSchemaRegistry.DEFAULT_CLIENT_ID)
+
+      consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString)
+      consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+
+      consumerProps
+    }
   }
 
-  protected def fillConsumerProps(): Properties = {
+  class KaaProducer() {
+    private val producer = createProducer()
 
-    consumerProps.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, KaaSchemaRegistry.DEFAULT_CLIENT_ID)
+    def close(maxWait: Duration): Unit = {
+      val maxWaitJava = JavaDuration.ofMillis(maxWait.toMillis)
+      producer.close(maxWaitJava)
+    }
 
-    consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString)
-    consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    def put(schema: Schema): SchemaId = {
+      if (stopping.get()) throw new UnsupportedOperationException("KaaSchemaRegistry is not available")
 
-    consumerProps
-  }
+      val fingerprint = SchemaNormalization.parsingFingerprint64(schema)
 
-  protected def createProducer(): KafkaProducer[lang.Long, String] = {
-    new KafkaProducer(fillProducerProps(), new LongSerializer(), new StringSerializer())
-  }
+      if (cache.getIfPresent(fingerprint).isEmpty) {
+        val record = new ProducerRecord[java.lang.Long, String](topic, fingerprint, schema.toString())
+        producer.send(record).get()
+      }
 
-  protected def fillProducerProps(): Properties = {
-    producerProps.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, KaaSchemaRegistry.DEFAULT_CLIENT_ID)
+      SchemaId(fingerprint)
+    }
 
-    producerProps
+    protected def createProducer(): KafkaProducer[lang.Long, String] = {
+      new KafkaProducer(fillProducerProps(), new LongSerializer(), new StringSerializer())
+    }
+
+    protected def fillProducerProps(): Properties = {
+      producerProps.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, KaaSchemaRegistry.DEFAULT_CLIENT_ID)
+
+      producerProps
+    }
   }
 }

--- a/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/KaaSchemaRegistry.scala
@@ -1,29 +1,27 @@
 package kaa.schemaregistry
 
 import java.lang
-
 import org.apache.avro.Schema
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.avro.SchemaNormalization
 import org.apache.kafka.clients.consumer.KafkaConsumer
+
 import java.util.{Collections, Properties, UUID}
 import java.time.{Duration => JavaDuration}
-
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{LongDeserializer, StringDeserializer}
 import org.apache.kafka.common.serialization.{LongSerializer, StringSerializer}
+import org.apache.kafka.clients.CommonClientConfigs
 
-import scala.concurrent.duration._
 import kaa.schemaregistry.utils.Retry
-import java.util.concurrent.atomic.AtomicBoolean
-
+import kaa.schemaregistry.utils.RetryConfig
 import kaa.schemaregistry.KaaSchemaRegistry._
 
+import scala.concurrent.duration._
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent._
-import kaa.schemaregistry.utils.RetryConfig
-import org.apache.kafka.clients.CommonClientConfigs
 
 object KaaSchemaRegistry {
   val DEFAULT_TOPIC_NAME = "schemas-v1"

--- a/kaa/src/main/scala/kaa/schemaregistry/exceptions.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/exceptions.scala
@@ -1,6 +1,8 @@
 package kaa.schemaregistry
 
 
-class InvalidSchemaException(s:String) extends Exception(s){}
+case class InvalidSchemaException(msg: String) extends Exception(msg)
 
-class SchemaNotFoundException(s:String) extends Exception(s){}
+case class SchemaNotFoundException(msg: String) extends Exception(msg)
+
+case class InvalidStateException(msg: String) extends Exception(msg)

--- a/kaa/src/main/scala/kaa/schemaregistry/kafka/KaaGenericSerde.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/kafka/KaaGenericSerde.scala
@@ -1,0 +1,40 @@
+package kaa.schemaregistry.kafka
+
+import kaa.schemaregistry.SchemaRegistry
+import kaa.schemaregistry.avro.GenericAvroSingleObjectSerializer
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.serialization._
+
+
+class KaaGenericSerde
+(schemaManager: SchemaRegistry)
+  extends Serde[GenericRecord]
+    with Deserializer[GenericRecord]
+    with Serializer[GenericRecord]
+    with Serializable {
+
+  private val avroSerializer = new GenericAvroSingleObjectSerializer(schemaManager)
+
+  def serializer: Serializer[GenericRecord] = this
+  def deserializer: Deserializer[GenericRecord] = this
+
+  override def deserialize(topic: String, data: Array[Byte]): GenericRecord = {
+    if (data == null || data.length == 0) {
+      null
+    } else {
+      avroSerializer.deserialize(data)
+    }
+  }
+
+  override def serialize(topic: String, data: GenericRecord): Array[Byte] = {
+    if (data == null) {
+      Array()
+    } else {
+      avroSerializer.serialize(data)
+    }
+  }
+
+  override def close(): Unit = ()
+
+  override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = ()
+}

--- a/kaa/src/main/scala/kaa/schemaregistry/kafka/KaaSerde.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/kafka/KaaSerde.scala
@@ -5,7 +5,13 @@ import kaa.schemaregistry.SchemaRegistry
 import kaa.schemaregistry.avro.AvroSingleObjectSerializer
 import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
 
-class GenericSerde[T >: Null : SchemaFor : Encoder : Decoder]
+object KaaSerde {
+  implicit def create[T >: Null : SchemaFor : Encoder : Decoder](implicit sr: SchemaRegistry): Serde[T] = {
+    new KaaSerde(sr)
+  }
+}
+
+class KaaSerde[T >: Null : SchemaFor : Encoder : Decoder]
 (schemaManager: SchemaRegistry)
   extends Serde[T]
     with Deserializer[T]

--- a/kaa/src/test/scala/kaa/schemaregistry/kafka/KaaGenericSerdeSpec.scala
+++ b/kaa/src/test/scala/kaa/schemaregistry/kafka/KaaGenericSerdeSpec.scala
@@ -1,0 +1,41 @@
+package kaa.schemaregistry.kafka
+
+import kaa.schemaregistry.test.TestSchemaRegistry
+import org.apache.avro.generic.GenericData
+import org.scalatest.flatspec._
+import org.scalatest.matchers._
+
+class KaaGenericSerdeSpec extends AnyFlatSpec with should.Matchers {
+
+  private val registry = new TestSchemaRegistry
+
+  private val schema =
+    """
+      |{"namespace": "example.avro",
+      | "type": "record",
+      | "name": "User",
+      | "fields": [
+      |     {"name": "name", "type": "string"},
+      |     {"name": "favorite_number",  "type": "int"},
+      |     {"name": "favorite_color", "type": "string"}
+      | ]
+      |}
+    """.stripMargin
+
+  "KaaGenericSerde" should "serialize and deserialize a generic record" in {
+    val target = new KaaGenericSerde(registry)
+
+    val schemaObj = new org.apache.avro.Schema.Parser().parse(schema)
+
+    val user1 = new GenericData.Record(schemaObj)
+    user1.put("name", "Alyssa")
+    user1.put("favorite_number", 256)
+    user1.put("favorite_color", "blue")
+
+    val bytes = target.serialize("topic", user1)
+    val result = target.deserialize("topic", bytes)
+
+    result.toString should equal ("{\"name\": \"Alyssa\", \"favorite_number\": 256, \"favorite_color\": \"blue\"}")
+  }
+
+}

--- a/kaa/src/test/scala/kaa/schemaregistry/kafka/KaaSerdeSpec.scala
+++ b/kaa/src/test/scala/kaa/schemaregistry/kafka/KaaSerdeSpec.scala
@@ -5,12 +5,12 @@ import flatspec._
 import matchers._
 import kaa.schemaregistry.test.TestSchemaRegistry
 
-class GenericSerdeSpec extends AnyFlatSpec with should.Matchers {
+class KaaSerdeSpec extends AnyFlatSpec with should.Matchers {
 
   val registry = new TestSchemaRegistry
 
-  "GenericSerde" should "serialize and deserialize a case class" in {
-    val target = new GenericSerde[FooUser](registry)
+  "KaaSerde" should "serialize and deserialize a case class" in {
+    val target = new KaaSerde[FooUser](registry)
 
     val expected = FooUser("foo")
     val bytes = target.serialize("topic", expected)
@@ -20,7 +20,7 @@ class GenericSerdeSpec extends AnyFlatSpec with should.Matchers {
   }
 
   it should "serialize and deserialize an Option Some" in {
-    val target = new GenericSerde[Option[FooUser]](registry)
+    val target = new KaaSerde[Option[FooUser]](registry)
 
     val expected = Some(FooUser("foo"))
     val bytes = target.serialize("topic", expected)
@@ -29,7 +29,7 @@ class GenericSerdeSpec extends AnyFlatSpec with should.Matchers {
   }
 
   it should "serialize and deserialize an Option None" in {
-    val target = new GenericSerde[Option[FooUser]](registry)
+    val target = new KaaSerde[Option[FooUser]](registry)
 
     val expected: Option[FooUser] = None
     val bytes = target.serialize("topic", expected)
@@ -38,7 +38,7 @@ class GenericSerdeSpec extends AnyFlatSpec with should.Matchers {
   }
 
   it should "serialize and deserialize a null" in {
-    val target = new GenericSerde[FooUser](registry)
+    val target = new KaaSerde[FooUser](registry)
 
     val expected: FooUser = null
     val bytes = target.serialize("topic", expected)

--- a/sample/src/main/scala/sampleApp.scala
+++ b/sample/src/main/scala/sampleApp.scala
@@ -2,6 +2,8 @@ import kaa.schemaregistry.avro.{AvroSingleObjectEncoding, AvroSingleObjectSerial
 import kaa.schemaregistry.KaaSchemaRegistry
 import kaa.schemaregistry.KaaSchemaRegistryAdmin
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object SampleApp {
     
     def main(args: Array[String]): Unit = {
@@ -16,8 +18,10 @@ object SampleApp {
             admin.close()
         }
 
-        val schemaRegistry = new KaaSchemaRegistry(brokers)
+        val schemaRegistry = new KaaSchemaRegistry(brokers, e => println(e))
         try {
+            schemaRegistry.start()
+
             val serializerV1 = new AvroSingleObjectSerializer[SuperheroV1](schemaRegistry)
             val serializerV2 = new AvroSingleObjectSerializer[SuperheroV2](schemaRegistry)
 


### PR DESCRIPTION
- Rename `GenericSerde` to `KaaSerde` (to support case classes serialization/deserialization)
- Add `KaaGenericSerde` to support serialization/deserialization of `GenericRecord`.
- Add `KaaSerde` and `KaaGenericSerde` implicits (close #42)
- `KaaSchemaRegistry.start` should be called to connect to Kafka and start consuming records (instead of automatically connect in constructor). This is to have a more controller life cycle, for example creating the instance but do not connect yet (useful for DI). And now you can `close` and `start` multiple times reusing the same instance. (close #36)