### PR TITLE
root primitive types support

### DIFF
--- a/kaa/src/main/scala/kaa/schemaregistry/avro/AvroSingleObjectSerializer.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/avro/AvroSingleObjectSerializer.scala
@@ -4,7 +4,7 @@ import com.sksamuel.avro4s._
 import kaa.schemaregistry.SchemaRegistry
 import kaa.schemaregistry.SchemaNotFoundException
 
-class AvroSingleObjectSerializer[T >: Null : SchemaFor : Encoder : Decoder]
+class AvroSingleObjectSerializer[T : SchemaFor : Encoder : Decoder]
 (
   schemaRegistry: SchemaRegistry,
   encoding: AvroSingleObjectEncoding = AvroSingleObjectEncoding.AVRO_OFFICIAL
@@ -21,7 +21,7 @@ class AvroSingleObjectSerializer[T >: Null : SchemaFor : Encoder : Decoder]
   def deserialize(bytes: Array[Byte]): T = {
     val (schemaId, serialized) = encoding.decode(bytes)
     val schema = schemaRegistry.get(schemaId)
-      .getOrElse(throw new SchemaNotFoundException(s"Schema $schemaId not found in registry"))
+      .getOrElse(throw SchemaNotFoundException(s"Schema $schemaId not found in registry"))
 
     binarySerializer.read(serialized, schema)
   }

--- a/kaa/src/main/scala/kaa/schemaregistry/avro/GenericAvroBinarySerializer.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/avro/GenericAvroBinarySerializer.scala
@@ -1,11 +1,10 @@
 package kaa.schemaregistry.avro
 
 import org.apache.avro._
-import java.io.ByteArrayOutputStream
-
-import org.apache.avro.file.SeekableByteArrayInput
 import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.io.{DecoderFactory, EncoderFactory}
+
+import java.io.ByteArrayOutputStream
 
 class GenericAvroBinarySerializer() {
   def write(record: GenericRecord): Array[Byte] = {
@@ -30,12 +29,7 @@ class GenericAvroBinarySerializer() {
       writerSchema,
       readerSchema.getOrElse(writerSchema)
     )
-    val inputStream = new SeekableByteArrayInput(bytes)
-    try {
-      val decoder = DecoderFactory.get.binaryDecoder(inputStream, null)
-      datumReader.read(null, decoder)
-    } finally {
-      inputStream.close()
-    }
+    val decoder = DecoderFactory.get.binaryDecoder(bytes, null)
+    datumReader.read(null, decoder)
   }
 }

--- a/kaa/src/main/scala/kaa/schemaregistry/kafka/KaaSerde.scala
+++ b/kaa/src/main/scala/kaa/schemaregistry/kafka/KaaSerde.scala
@@ -11,7 +11,7 @@ object KaaSerde {
   }
 }
 
-class KaaSerde[T >: Null : SchemaFor : Encoder : Decoder]
+class KaaSerde[T : SchemaFor : Encoder : Decoder]
 (schemaManager: SchemaRegistry)
   extends Serde[T]
     with Deserializer[T]
@@ -25,7 +25,7 @@ class KaaSerde[T >: Null : SchemaFor : Encoder : Decoder]
 
   override def deserialize(topic: String, data: Array[Byte]): T = {
     if (data == null || data.length == 0) {
-      null
+      null.asInstanceOf[T]
     } else {
       avroSerializer.deserialize(data)
     }

--- a/kaa/src/test/scala/kaa/schemaregistry/avro/AvroSingleObjectSerializerSpec.scala
+++ b/kaa/src/test/scala/kaa/schemaregistry/avro/AvroSingleObjectSerializerSpec.scala
@@ -8,30 +8,74 @@ import kaa.schemaregistry.SchemaId
 import kaa.schemaregistry.test.TestSchemaRegistry
 import matchers._
 
+import java.util.UUID
+
 case class Pokemon(name: String, mainType: String, offType: Option[String], level: Int)
 
 class AvroSingleObjectSerializerSpec extends AnyFlatSpec with should.Matchers {
 
   val registry = new TestSchemaRegistry
-  val dragonite = Pokemon("Dragonite", "Dragon", None, 100)
-
-  val singleObjectSerializer = new AvroSingleObjectSerializer[Pokemon](registry)
 
   "AvroSingleObjectSerializer" should "serialize and deserialize a case class" in {
-    val encoded = singleObjectSerializer.serialize(dragonite)
-    val decoded = singleObjectSerializer.deserialize(encoded)
+    val target = new AvroSingleObjectSerializer[Pokemon](registry)
 
-    decoded.equals(dragonite) should be (true)
+    val expected = Pokemon("Dragonite", "Dragon", None, 100)
+    val encoded = target.serialize(expected)
+    val decoded = target.deserialize(encoded)
+
+    decoded.equals(expected) should be (true)
   }
 
   it should "serialize a class with a single object encoding" in {
-    val encoded = singleObjectSerializer.serialize(dragonite)
+    val target = new AvroSingleObjectSerializer[Pokemon](registry)
+
+    val expected = Pokemon("Dragonite", "Dragon", None, 100)
+    val encoded = target.serialize(expected)
 
     val (schemaId, bin) = AvroSingleObjectEncoding.AVRO_OFFICIAL.decode(encoded)
     val binarySerializer = new AvroBinarySerializer[Pokemon]
 
     schemaId should be (AvroUtils.calcFingerprint(AvroSchema[Pokemon]))
-    bin should be (binarySerializer.write(dragonite))
+    bin should be (binarySerializer.write(expected))
+  }
+
+  it should "serialize and deserialize a primitive type: Long" in {
+    val target = new AvroSingleObjectSerializer[Long](registry)
+
+    val expected = 81L
+    val encoded = target.serialize(expected)
+    val decoded = target.deserialize(encoded)
+    decoded should be (expected)
+
+    val (schemaId, _) = AvroSingleObjectEncoding.AVRO_OFFICIAL.decode(encoded)
+    schemaId should be (SchemaId(-3434872931120570953L))
+    schemaId should be (AvroUtils.calcFingerprint(AvroSchema[Long]))
+  }
+
+  it should "serialize and deserialize a primitive type: String" in {
+    val target = new AvroSingleObjectSerializer[String](registry)
+
+    val expected = "hello world!"
+    val encoded = target.serialize(expected)
+    val decoded = target.deserialize(encoded)
+    decoded should be (expected)
+
+    val (schemaId, _) = AvroSingleObjectEncoding.AVRO_OFFICIAL.decode(encoded)
+    schemaId should be (SchemaId(-8142146995180207161L))
+    schemaId should be (AvroUtils.calcFingerprint(AvroSchema[String]))
+  }
+
+  it should "serialize and deserialize a primitive type: UUID" in {
+    val target = new AvroSingleObjectSerializer[UUID](registry)
+
+    val expected = UUID.randomUUID()
+    val encoded = target.serialize(expected)
+    val decoded = target.deserialize(encoded)
+    decoded should be (expected)
+
+    val (schemaId, _) = AvroSingleObjectEncoding.AVRO_OFFICIAL.decode(encoded)
+    schemaId should be (SchemaId(-8142146995180207161L))
+    schemaId should be (AvroUtils.calcFingerprint(AvroSchema[UUID]))
   }
 
   object AvroUtils {

--- a/kaa/src/test/scala/kaa/schemaregistry/kafka/KaaSerdeSpec.scala
+++ b/kaa/src/test/scala/kaa/schemaregistry/kafka/KaaSerdeSpec.scala
@@ -5,6 +5,8 @@ import flatspec._
 import matchers._
 import kaa.schemaregistry.test.TestSchemaRegistry
 
+import java.util.UUID
+
 class KaaSerdeSpec extends AnyFlatSpec with should.Matchers {
 
   val registry = new TestSchemaRegistry
@@ -37,7 +39,8 @@ class KaaSerdeSpec extends AnyFlatSpec with should.Matchers {
     result should equal (expected)
   }
 
-  it should "serialize and deserialize a null" in {
+  // tomb stone support
+  it should "serialize and deserialize a case class from null" in {
     val target = new KaaSerde[FooUser](registry)
 
     val expected: FooUser = null
@@ -45,6 +48,54 @@ class KaaSerdeSpec extends AnyFlatSpec with should.Matchers {
     val result = target.deserialize("topic", bytes)
 
     result should equal (expected)
+  }
+
+  it should "serialize and deserialize primitive type: String" in {
+    val target = new KaaSerde[String](registry)
+
+    val expected = "hello world"
+    val bytes = target.serialize("topic", expected)
+    val result = target.deserialize("topic", bytes)
+
+    result should equal (expected)
+  }
+
+  it should "serialize and deserialize primitive type: Long" in {
+    val target = new KaaSerde[Long](registry)
+
+    val expected = 81L
+    val bytes = target.serialize("topic", expected)
+    val result = target.deserialize("topic", bytes)
+
+    result should equal (expected)
+  }
+
+  it should "serialize and deserialize primitive type: UUID" in {
+    val target = new KaaSerde[UUID](registry)
+
+    val expected = UUID.randomUUID()
+    val bytes = target.serialize("topic", expected)
+    val result = target.deserialize("topic", bytes)
+
+    result should equal (expected)
+  }
+
+  it should "deserialize null to primitive type: Long" in {
+    val target = new KaaSerde[Long](registry)
+    target.deserialize("topic", Array()) == 0L should be (true)
+    target.deserialize("topic", null) == 0L should be (true)
+  }
+
+  it should "deserialize null to primitive type: String" in {
+    val target = new KaaSerde[String](registry)
+    target.deserialize("topic", Array()) should be (null)
+    target.deserialize("topic", null) should be (null)
+  }
+
+  it should "deserialize null to primitive type: UUID" in {
+    val target = new KaaSerde[UUID](registry)
+    target.deserialize("topic", Array()) should be (null)
+    target.deserialize("topic", null) should be (null)
   }
 
   case class FooUser (name: String) {


### PR DESCRIPTION
Allow to serialize and deserialize primitive types (like `String`, `Long`, `UUID`) as root types, not only classes as before.